### PR TITLE
AB#108627 rename to TEST_PATH 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Any recent Playwright Test 1.x release should work; align with what you already 
 The following must be set (locally via .env, or in CI via your provider's secrets/variables):
  * `CANVAS_HOST` - trailing slash is optional
  * `OAUTH_TOKEN`
- * `DEPLOYMENT_TEST_PATH` - leading slash is optional (Previously named `URL` which was changed as it was found to be confusing.)
+ * `TEST_PATH` - leading slash is optional (Previously named `URL` which was changed as it was found to be confusing.)
 
 
 If any are missing, `assertVariables.js` will fail fast to help you diagnose configuration.
@@ -56,7 +56,7 @@ Example:
 ```bash
 CANVAS_HOST=https://wibble.instructure.com
 OAUTH_TOKEN=12345~QWERTYUIOPASDFGHJKLZXCVBNM
-DEPLOYMENT_TEST_PATH=/accounts/1/external_tools/789
+TEST_PATH=/accounts/1/external_tools/789
 ```
 
 Use the utilities from this repository when writing your deployment tests. Here's a simple example which asserts that some specific text, `XXXXXXXXXXXXXXX`, appears on a page. The test(s) can be as simple or as complex as seems appropriate.
@@ -66,7 +66,7 @@ import { test, expect } from '@playwright/test'
 import { dismissBetaBanner, getLtiIFrame, waitForNoSpinners } from '@oxctl/deployment-test-utils'
 
 const host = process.env.CANVAS_HOST
-const url = process.env.DEPLOYMENT_TEST_PATH
+const url = process.env.TEST_PATH
 
 test.describe('Test deployment', () => {
     test('The tool should load and the text "XXXXXXXXXXXXXXX" should be shown', async ({context, page}) => {

--- a/src/setup/assertVariables.js
+++ b/src/setup/assertVariables.js
@@ -1,15 +1,15 @@
 import { test, expect } from '@playwright/test'
 import 'dotenv/config'
 
-const REQUIRED = ['CANVAS_HOST', 'OAUTH_TOKEN', 'DEPLOYMENT_TEST_PATH']
+const REQUIRED = ['CANVAS_HOST', 'OAUTH_TOKEN', 'TEST_PATH']
 
 
 // Normalise environment variables at module load time
 if (process.env.CANVAS_HOST) {
   process.env.CANVAS_HOST = process.env.CANVAS_HOST.trim().replace(/\/+$/, '');
 }
-if (process.env.DEPLOYMENT_TEST_PATH) {
-  process.env.DEPLOYMENT_TEST_PATH = process.env.DEPLOYMENT_TEST_PATH.trim().replace(/^\/+/, '');
+if (process.env.TEST_PATH) {
+  process.env.TEST_PATH = process.env.TEST_PATH.trim().replace(/^\/+/, '');
 }
 
 test('required environment variables are set', async () => {

--- a/src/setup/auth.setup.js
+++ b/src/setup/auth.setup.js
@@ -9,7 +9,7 @@ const authFile = path.resolve(process.cwd(), 'playwright/.auth/user.json')
 
 const hostRaw = process.env.CANVAS_HOST || ''
 const token   = process.env.OAUTH_TOKEN
-const urlRaw  = process.env.DEPLOYMENT_TEST_PATH || ''
+const urlRaw  = process.env.TEST_PATH || ''
 
 // Normalize: remove trailing slashes from host, and leading slashes from url
 const host = hostRaw.replace(/\/+$/, '')

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test'
 
 // Return a valid URL of the test course or account - assertVariables.js will
 //  ensure these env vars exist and are normalised.
-export const TEST_URL = process.env.CANVAS_HOST + "/" + process.env.DEPLOYMENT_TEST_PATH
+export const TEST_URL = process.env.CANVAS_HOST + "/" + process.env.TEST_PATH
 
 
 export const login = async (request, page, host, token) => {


### PR DESCRIPTION
The name used to be DEPLOYMENT_TEST_PATH but the "DEPLOYMENT_" prefix isnt necessary and doesnt follow the same pattern as other env vars